### PR TITLE
KS-102: 가게 상세페이지 메뉴 순서 적용

### DIFF
--- a/src/global/exception/menus-exception.ts
+++ b/src/global/exception/menus-exception.ts
@@ -11,4 +11,5 @@ export abstract class MenusException {
     static ENTITY_NOT_FOUND = new CommonException('존재하지 않는 메뉴입니다.', 3002, HttpStatus.NOT_FOUND);
     static STATUS_NOT_FOUND = new CommonException('식별되지않은 메뉴 상태입니다.', 3003, HttpStatus.NOT_FOUND);
     static FILTER_TYPE_NOT_FOUND = new CommonException('식별되지않은 필터링 타입입니다.', 3004, HttpStatus.NOT_FOUND);
+    static ANY_MENUS_NOT_FOUND = new CommonException('검색되는 메뉴가 존재하지 않습니다.', 3005, HttpStatus.NOT_FOUND);
 }

--- a/src/menus/entity/menu.entity.ts
+++ b/src/menus/entity/menu.entity.ts
@@ -39,7 +39,7 @@ export class Menu extends SoftDeleteEntity<Menu> {
     @Column({ comment: '메뉴에 관한 설명' })
     description: string;
 
-    @ManyToOne(() => Store, (store) => store.menus, { cascade: ['soft-remove'] })
+    @ManyToOne(() => Store, (store) => store.menus, { onDelete: 'CASCADE', cascade: ['soft-remove'] })
     store: Store;
 
     @OneToOne(() => MenuView, (view) => view.menu, { cascade: ['insert'] })

--- a/src/menus/menus.repository.ts
+++ b/src/menus/menus.repository.ts
@@ -59,7 +59,7 @@ export class MenusRepository {
     }
 
     async delete(menu: Menu) {
-        await this.menus.delete({ id: menu.id });
+        await this.menus.softDelete({ id: menu.id });
     }
 
     async create(store: Store, args: CreateMenuArgs) {

--- a/src/menus/menus.service.ts
+++ b/src/menus/menus.service.ts
@@ -92,18 +92,18 @@ export class MenusService {
     }
 
     async findManyForSeller(store: Store, status?: MenuStatus) {
-        let where = `menus.store_id = "${store.id}"`;
+        let where = `m.store_id = "${store.id}"`;
         switch (status) {
             case undefined: // status가 비어있는경우 -> 메뉴 전체 조회
                 break;
             case MenuStatus.SALE:
-                where += ` AND menus.status = "${MenuStatus.SALE}"`;
+                where += ` AND m.status = "${MenuStatus.SALE}"`;
                 break;
             case MenuStatus.SOLDOUT:
-                where += ` AND menus.status = "${MenuStatus.SOLDOUT}"`;
+                where += ` AND m.status = "${MenuStatus.SOLDOUT}"`;
                 break;
             case MenuStatus.HIDDEN:
-                where += ` AND menus.status = "${MenuStatus.HIDDEN}"`;
+                where += ` AND m.status = "${MenuStatus.HIDDEN}"`;
                 break;
             default:
                 throw MenusException.STATUS_NOT_FOUND;
@@ -112,14 +112,14 @@ export class MenusService {
         const orderBy = await this.storesRepository.processOrderBy(store);
 
         const data = await this.entityManager
-            .createQueryBuilder(Menu, 'menus')
+            .createQueryBuilder(Menu, 'm')
             .select(
-                'menus.id, menus.name, menus.discount_rate AS discountRate, menus.sale_price AS sellingPrice, menus.price, menus.menu_picture_url AS menuPictureUrl, menus.status',
+                'm.id, m.name, m.discount_rate AS discountRate, m.sale_price AS sellingPrice, m.price, m.menu_picture_url AS menuPictureUrl, m.status',
             )
             .where(where)
-            .orderBy(`menus.status = "${MenuStatus.SALE}"`, 'DESC')
-            .addOrderBy(`menus.status = "${MenuStatus.SOLDOUT}"`, 'DESC')
-            .addOrderBy(`menus.status = "${MenuStatus.HIDDEN}"`, 'DESC')
+            .orderBy(`m.status = "${MenuStatus.SALE}"`, 'DESC')
+            .addOrderBy(`m.status = "${MenuStatus.SOLDOUT}"`, 'DESC')
+            .addOrderBy(`m.status = "${MenuStatus.HIDDEN}"`, 'DESC')
             .addOrderBy(orderBy, 'DESC')
             .getRawMany();
         return data;

--- a/src/menus/menus.service.ts
+++ b/src/menus/menus.service.ts
@@ -166,6 +166,9 @@ export class MenusService {
             .addOrderBy('m.discount_rate', 'DESC')
             .addOrderBy('m.created_date')
             .getRawMany();
+        if (!dataList.length) {
+            throw MenusException.ANY_MENUS_NOT_FOUND;
+        }
         let prevCategory;
         for (const data of dataList) {
             if (prevCategory != data.category) {
@@ -217,6 +220,9 @@ export class MenusService {
             .orderBy('c.name')
             .addOrderBy(orderBy, 'ASC')
             .getRawMany();
+        if (!dataList.length) {
+            throw MenusException.ANY_MENUS_NOT_FOUND;
+        }
 
         let prevCategory = dataList[0].category;
         let prevArray = [];
@@ -255,20 +261,6 @@ export class MenusService {
     }
 
     private processDetailMenu(data) {
-        const menu = {
-            id: data.menuId,
-            menuPictureUrl: data.menuPictureUrl,
-            name: data.menuName,
-            price: data.price,
-            discountRate: data.discountRate,
-            sellingPrice: data.sellingPrice,
-        };
-        const store = { name: data.storeName, menu };
-        const pushData = { category: data.category, store };
-        return pushData;
-    }
-
-    private processDiscountedMenus(data) {
         const menu = {
             id: data.menuId,
             menuPictureUrl: data.menuPictureUrl,

--- a/src/stores/stores.repository.ts
+++ b/src/stores/stores.repository.ts
@@ -117,7 +117,7 @@ export class StoresRepository {
     }
 
     async processOrderBy(store: Store) {
-        let orderBy = 'FIELD(';
+        let orderBy = 'FIELD(m.id, ';
         const processingOrder = await this.findOrder(store);
         while (processingOrder.length > 1) {
             const menuId = processingOrder.pop();

--- a/src/stores/stores.service.ts
+++ b/src/stores/stores.service.ts
@@ -91,51 +91,69 @@ export class StoresService {
     }
 
     async findStore(storeId: number) {
-        const store = await this.findOneStore(
-            {
-                id: storeId,
-                approve: {
-                    isApproved: true,
-                },
-            },
-            {
-                id: true,
-                name: true,
-                status: true,
-                categories: {
-                    name: true,
-                },
-                detail: {
-                    address: true,
-                    addressDetail: true,
-                    lat: true,
-                    lon: true,
-                    phone: true,
-                    cookingTime: true,
-                    operationTimes: {
-                        startedAt: true,
-                        endedAt: true,
-                    },
-                    menuOrders: true,
-                },
-                menus: {
-                    id: true,
-                    name: true,
-                    menuPictureUrl: true,
-                    discountRate: true,
-                    salePrice: true,
-                    price: true,
-                    countryOfOrigin: true,
-                    description: true,
-                },
-            },
-            {
-                categories: true,
-                detail: true,
-                menus: true,
-            },
-        );
+        const orderBy = await this.storesRepository.processOrderBy(await this.findOneStore({ id: storeId }));
+        const dataList = await this.entityManager
+            .createQueryBuilder(Menu, 'm')
+            .leftJoinAndSelect(Store, 's', 's.id = m.store_id')
+            .leftJoinAndSelect(StoreApprove, 'sa', 's.id = sa.store_id')
+            .leftJoinAndSelect(StoreDetail, 'sd', 's.id = sd.store_id')
+            .leftJoin('store_categories', 'sc', 's.id = sc.stores_id')
+            .leftJoinAndSelect(Category, 'c', 'sc.categories_id = c.id')
+            .select('s.id', 'storeId')
+            .addSelect('s.name', 'storeName')
+            .addSelect('s.status', 'storeStatus')
+            .addSelect('c.name', 'category')
+            .addSelect('sd.address', 'address')
+            .addSelect('sd.address_detail', 'addressDetail')
+            .addSelect('sd.lat', 'lat')
+            .addSelect('sd.lon', 'lon')
+            .addSelect('sd.phone', 'phone')
+            .addSelect('sd.cooking_time', 'cookingTime')
+            .addSelect('sd.operation_times', 'operationTimes')
+            .addSelect('sd.menu_orders', 'menuOrders')
+            .addSelect('m.id', 'menuId')
+            .addSelect('m.name', 'menuName')
+            .addSelect('m.discount_rate', 'discountRate')
+            .addSelect('m.sale_price', 'salePrice')
+            .addSelect('m.price', 'price')
+            .addSelect('m.menu_picture_url', 'menuPictureUrl')
+            .addSelect('m.country_of_origin', 'countryOfOrigin')
+            .addSelect('m.description', 'description')
+            .where('s.id = :storeId', { storeId })
+            .andWhere('sa.is_approved = :isApproved', { isApproved: 1 })
+            .orderBy(orderBy, 'DESC')
+            .getRawMany();
 
+        const menuList = [];
+        for (const menu of dataList) {
+            const refinedMenuData = {
+                id: menu.menuId,
+                name: menu.menuName,
+                discountRate: menu.discountRate,
+                salePrice: menu.salePrice,
+                price: menu.price,
+                menuPictureUrl: menu.menuPictureUrl,
+                countryOfOrigin: menu.countryOfOrigin,
+                description: menu.description,
+            };
+            menuList.push(refinedMenuData);
+        }
+        const store = {
+            id: dataList[0].storeId,
+            name: dataList[0].storeName,
+            categories: [{ name: dataList[0].category }],
+            detail: {
+                address: dataList[0].address,
+                addressDetail: dataList[0].addressDetail,
+                lat: dataList[0].lat,
+                lon: dataList[0].lon,
+                phone: dataList[0].phone,
+                cookingTime: dataList[0].cookingTime,
+                operationTimes: dataList[0].operationTimes,
+                menuOrders: dataList[0].menuOrders,
+            },
+            menus: menuList,
+        };
         if (!store) {
             throw StoresException.ENTITY_NOT_FOUND;
         }


### PR DESCRIPTION
## 가게 상세페이지 메뉴 순서 적용
을 하기로 만든 브랜치였지만,, 다른 걸 또 해버렸습니다

### 추가 변경사항
1. menu cascade옵션 추가(user삭제시 그 user의 store와 menu들 삭제)
2. 홈화면 API(할인율 가장 높은 메뉴 조회, 지금 먹으면 할인 메뉴 조회) 예외처리 추가
3. menu soft-delete옵션 적용