### PR TITLE
KS-106: 메뉴 상태 변경 API 추가

### DIFF
--- a/src/menus/dto/update-menu.dto.ts
+++ b/src/menus/dto/update-menu.dto.ts
@@ -12,10 +12,6 @@ export class UpdateMenuDto implements UpdateMenuArgs {
     name?: string;
 
     @IsOptional()
-    @IsEnum(MenuStatus)
-    status?: MenuStatus;
-
-    @IsOptional()
     @IsNumber()
     price?: number;
 

--- a/src/menus/dto/update-status.dto.ts
+++ b/src/menus/dto/update-status.dto.ts
@@ -1,0 +1,13 @@
+import { IsEnum, IsNotEmpty, IsNumber } from 'class-validator';
+import { UpdateStatusArgs } from '../interface/update-status.interface';
+import { MenuStatus } from '../enum/menu-status.enum';
+
+export class UpdateMenuStatusDto implements UpdateStatusArgs {
+    @IsEnum(MenuStatus)
+    @IsNotEmpty()
+    prevStatus: MenuStatus;
+
+    @IsEnum(MenuStatus)
+    @IsNotEmpty()
+    updateStatus: MenuStatus;
+}

--- a/src/menus/interface/update-menu.interface.ts
+++ b/src/menus/interface/update-menu.interface.ts
@@ -4,7 +4,6 @@ export interface UpdateMenuArgs {
     menuPictureUrl?: string;
     name?: string;
     description?: string;
-    status?: MenuStatus;
     price?: number;
     discountRate?: number;
 }

--- a/src/menus/interface/update-status.interface.ts
+++ b/src/menus/interface/update-status.interface.ts
@@ -1,0 +1,6 @@
+import { MenuStatus } from '../enum/menu-status.enum';
+
+export interface UpdateStatusArgs {
+    prevStatus: MenuStatus;
+    updateStatus: MenuStatus;
+}

--- a/src/menus/menus.controller.ts
+++ b/src/menus/menus.controller.ts
@@ -30,6 +30,7 @@ import { FindAsLocationDto } from './dto/find-as-loaction.dto';
 import { MenuFilterType } from './enum/discounted-menu-filter-type.enum';
 import { MenuStatus } from './enum/menu-status.enum';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { UpdateMenuStatusDto } from './dto/update-status.dto';
 
 @Controller('menus')
 export class MenusController {
@@ -79,6 +80,12 @@ export class MenusController {
     @Get('/discounted')
     async findManyDiscount(@Query('type') type: MenuFilterType, @Query() dto: FindAsLocationDto) {
         return await this.menusService.findManyDiscount(type, dto);
+    }
+
+    @Put('/status/:id')
+    @UseGuards(AuthGuard)
+    async updateStatus(@Param('id', TransformMenuPipe) menu: Menu, @Body() dto: UpdateMenuStatusDto) {
+        return await this.menusService.updateStatus(menu, dto);
     }
 
     @Post('upload/:storeId')

--- a/src/menus/menus.repository.ts
+++ b/src/menus/menus.repository.ts
@@ -46,6 +46,10 @@ export class MenusRepository {
             .getRawOne();
     }
 
+    async incrementView(menu: Menu) {
+        return await this.menuView.increment({ id: menu.id }, 'viewCount', 1);
+    }
+
     async exist(where: FindManyOptions<Menu>) {
         return await this.menus.exist(where);
     }

--- a/src/menus/menus.service.ts
+++ b/src/menus/menus.service.ts
@@ -165,7 +165,8 @@ export class MenusService {
             order.splice(idx, 1);
         }
         await this.updateOrder(menu.store, { order });
-        return this.menusRepository.update(menu, { status: dto.updateStatus });
+        this.menusRepository.update(menu, { status: dto.updateStatus });
+        return await this.findDetailOne(menu);
     }
 
     async findMaxDiscount(dto: FindAsLocationDto) {

--- a/src/menus/menus.service.ts
+++ b/src/menus/menus.service.ts
@@ -62,6 +62,11 @@ export class MenusService {
     }
 
     async delete(menu: Menu) {
+        // 메뉴 삭제시 순서에서도 삭제
+        const order = await this.storesRepository.findOrder(menu.store);
+        const idx = order.findIndex((id) => Number(id) === menu.id);
+        order.splice(idx, 1);
+        await this.updateOrder(menu.store, { order });
         return this.menusRepository.delete(menu);
     }
 

--- a/src/menus/menus.service.ts
+++ b/src/menus/menus.service.ts
@@ -88,6 +88,7 @@ export class MenusService {
             pickUpTime: refinedPickUpTime ? refinedPickUpTime : null, // 사용자의 거리값을 안 보냈을 경우(update 시) null로 전송
             caution,
         };
+        await this.menusRepository.incrementView(menu);
         return menuDetailList;
     }
 

--- a/src/menus/pipe/transform-menu.pipe.ts
+++ b/src/menus/pipe/transform-menu.pipe.ts
@@ -8,14 +8,17 @@ export class TransformMenuPipe implements PipeTransform {
     constructor(private readonly menusService: MenusService) {}
 
     async transform(value: number) {
-        const menu = await this.menusService.findOne({
-            id: value,
-        });
+        const menu = await this.menusService.findOne(
+            {
+                id: value,
+            },
+            {},
+            { store: true },
+        );
 
         if (!menu) {
             throw MenusException.ENTITY_NOT_FOUND;
         }
-
         return menu;
     }
 }


### PR DESCRIPTION
## 메뉴 상태 변경 API
- update로 메뉴 상태변경 진행했는데, 메뉴 순서쪽에 오류가 발생할 여지가 있어 상태 변경 API는 따로 분리했습니다.
- 따라서 기존의 update할때의 dto와 분리하여 새로운 dto를 작성하였습니다.

### 특이사항
- 메뉴 삭제시 순서에서도 삭제되도록 변경했습니다.