### PR TITLE
KS-115: 가게 운영 상태 조회 API 구현

### DIFF
--- a/src/stores/entity/store-approve.entity.ts
+++ b/src/stores/entity/store-approve.entity.ts
@@ -1,11 +1,12 @@
 import { AbstractEntity } from 'src/global/common/abstract.entity';
 import { Column, Entity, JoinColumn, OneToOne } from 'typeorm';
 import { Store } from './store.entity';
+import { StoreApproveStatus } from '../enum/store-approve-status.enum';
 
 @Entity()
 export class StoreApprove extends AbstractEntity<StoreApprove> {
-    @Column({ default: false })
-    isApproved: boolean;
+    @Column({ type: 'enum', enum: StoreApproveStatus, default: StoreApproveStatus.BEFORE })
+    isApproved: StoreApproveStatus;
 
     @OneToOne(() => Store, (store) => store.approve, { onDelete: 'CASCADE' })
     @JoinColumn()

--- a/src/stores/enum/store-approve-status.enum.ts
+++ b/src/stores/enum/store-approve-status.enum.ts
@@ -1,0 +1,5 @@
+export enum StoreApproveStatus {
+    BEFORE = 'before',
+    WAITING = 'waiting',
+    DONE = 'done',
+}

--- a/src/stores/enum/store-category.enum.ts
+++ b/src/stores/enum/store-category.enum.ts
@@ -1,6 +1,0 @@
-export enum StoreCategory {
-    Bakery = '제과/제빵',
-    Japanese = '일식',
-    Korean = '한식',
-    Chicken = '치킨',
-}

--- a/src/stores/stores.controller.ts
+++ b/src/stores/stores.controller.ts
@@ -115,6 +115,11 @@ export class StoresController {
         return await this.storesService.basicInfo(storeId);
     }
 
+    @Get('/operation/:id')
+    async checkOperationStatus(@Param('id', ParseIntPipe) storeId: number) {
+        return await this.storesService.checkApprove(storeId);
+    }
+
     @Post('upload/:storeId')
     @UseGuards(AuthGuard)
     @UseInterceptors(FileInterceptor('file'))

--- a/src/stores/stores.repository.ts
+++ b/src/stores/stores.repository.ts
@@ -19,6 +19,7 @@ import { Category } from 'src/categories/entity/category.entity';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { Menu } from 'src/menus/entity/menu.entity';
 import { StoresException } from 'src/global/exception/stores-exception';
+import { StoreApproveStatus } from './enum/store-approve-status.enum';
 
 @Injectable()
 export class StoresRepository {
@@ -71,7 +72,7 @@ export class StoresRepository {
 
     async approve(entity: StoreApprove) {
         await this.storeApprove.update(entity.id, {
-            isApproved: true,
+            isApproved: StoreApproveStatus.DONE,
         });
 
         await this.entityManager

--- a/src/stores/stores.service.ts
+++ b/src/stores/stores.service.ts
@@ -91,6 +91,15 @@ export class StoresService {
         return await this.storesRepository.approve(approve);
     }
 
+    async checkApprove(storeId: number) {
+        const storeApproveData = await this.storesRepository.findOneApprove({
+            store: {
+                id: storeId,
+            },
+        });
+        return { status: storeApproveData.isApproved };
+    }
+
     async onMapFindStore(storeId: number) {
         const qb = await this.entityManager
             .createQueryBuilder(Store, 's')
@@ -267,8 +276,6 @@ export class StoresService {
     }
 
     async initMockStores() {
-        const countryOfOrigin = [{ 닭고기: '국내산' }, { 김치: '국내산' }, { 고등어: '노르웨이산' }];
-
         const owners: User[] = [
             new User({
                 fId: 'owner0001',


### PR DESCRIPTION
## 가게 운영 상태 조회 API 구현
- Approve Status를 enum으로 만들어 관리합니다.
- store_approve테이블에서 isApprove 칼럼을 수정하였습니다.

### 특이사항
- 스토어 더미데이터를 추가하는 InitMockStores 메소드에서 원산지 표기를 없앴습니다.
- store-category enum을 삭제했습니다.