### PR TITLE
KS-114: 배너 조회 및 생성

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,7 @@ import { InitializeService } from './initialize.service';
 import { SmsModule } from './sms/sms.module';
 import { CacheModule } from './cache/cache.module';
 import { VersionModule } from './version/version.module';
+import { BannersModule } from './banners/banners.module';
 import aligoConfiguration from './global/config/aligo.configuration';
 
 @Module({
@@ -32,6 +33,7 @@ import aligoConfiguration from './global/config/aligo.configuration';
         SmsModule,
         CacheModule,
         VersionModule,
+        BannersModule,
     ],
     providers: [Logger, InitializeService],
 })

--- a/src/banners/banners.controller.ts
+++ b/src/banners/banners.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('banners')
+export class BannersController {}

--- a/src/banners/banners.controller.ts
+++ b/src/banners/banners.controller.ts
@@ -1,4 +1,18 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post, UploadedFile, UseGuards, UseInterceptors } from '@nestjs/common';
+import { BannersService } from './banners.service';
+import { AuthGuard } from 'src/auth/guard/auth.guard';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { CreateBannerDto } from './dto/create-banner.dto';
 
 @Controller('banners')
-export class BannersController {}
+export class BannersController {
+    constructor(private readonly bannerService: BannersService) {}
+
+    @Post('/upload')
+    @UseGuards(AuthGuard) // TODO: 어드민 권한
+    @UseInterceptors(FileInterceptor('file'))
+    async uploadImage(@UploadedFile() file: Express.MulterS3.File, @Body() formData: object) {
+        const dto: CreateBannerDto = JSON.parse(JSON.stringify(formData));
+        await this.bannerService.create(dto, file);
+    }
+}

--- a/src/banners/banners.controller.ts
+++ b/src/banners/banners.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, UploadedFile, UseGuards, UseInterceptors } from '@nestjs/common';
+import { Body, Controller, Get, Post, UploadedFile, UseGuards, UseInterceptors } from '@nestjs/common';
 import { BannersService } from './banners.service';
 import { AuthGuard } from 'src/auth/guard/auth.guard';
 import { FileInterceptor } from '@nestjs/platform-express';
@@ -14,5 +14,10 @@ export class BannersController {
     async uploadImage(@UploadedFile() file: Express.MulterS3.File, @Body() formData: object) {
         const dto: CreateBannerDto = JSON.parse(JSON.stringify(formData));
         await this.bannerService.create(dto, file);
+    }
+
+    @Get('')
+    async findAll() {
+        return await this.bannerService.findAll();
     }
 }

--- a/src/banners/banners.module.ts
+++ b/src/banners/banners.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { BannersService } from './banners.service';
+import { BannersController } from './banners.controller';
+
+@Module({
+  providers: [BannersService],
+  controllers: [BannersController]
+})
+export class BannersModule {}

--- a/src/banners/banners.module.ts
+++ b/src/banners/banners.module.ts
@@ -1,9 +1,22 @@
 import { Module } from '@nestjs/common';
 import { BannersService } from './banners.service';
 import { BannersController } from './banners.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Banner } from './entity/banner.entity';
+import { MulterModule } from '@nestjs/platform-express';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { multerS3Config } from 'src/global/config/multer-s3.config';
 
 @Module({
-  providers: [BannersService],
-  controllers: [BannersController]
+    imports: [
+        TypeOrmModule.forFeature([Banner]),
+        MulterModule.registerAsync({
+            imports: [ConfigModule],
+            inject: [ConfigService],
+            useFactory: (configService: ConfigService) => multerS3Config(configService),
+        }),
+    ],
+    providers: [BannersService],
+    controllers: [BannersController],
 })
 export class BannersModule {}

--- a/src/banners/banners.service.ts
+++ b/src/banners/banners.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class BannersService {}

--- a/src/banners/banners.service.ts
+++ b/src/banners/banners.service.ts
@@ -45,4 +45,14 @@ export class BannersService {
             } else throw error;
         });
     }
+
+    async findAll() {
+        const urlList = await this.entityManager
+            .createQueryBuilder(Banner, 'b')
+            .select('b.url AS url')
+            .where('is_visible = :isVisible', { isVisible: 1 })
+            .orderBy('orders', 'ASC')
+            .getRawMany();
+        return urlList.map((data) => data.url);
+    }
 }

--- a/src/banners/banners.service.ts
+++ b/src/banners/banners.service.ts
@@ -1,4 +1,48 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Banner } from './entity/banner.entity';
+import { EntityManager, Repository } from 'typeorm';
+import { CreateBannerDto } from './dto/create-banner.dto';
+import { BannerException } from 'src/global/exception/banners-exception';
+import { S3Exception } from 'src/global/exception/s3-exception';
+import { CategoriesException } from 'src/global/exception/categories-exception';
+import { CreateBannerInterface } from './interface/create-banner.interface';
 
 @Injectable()
-export class BannersService {}
+export class BannersService {
+    constructor(
+        @InjectRepository(Banner) private bannerRepository: Repository<Banner>,
+        private readonly entityManager: EntityManager,
+    ) {}
+
+    async create(dto: CreateBannerInterface, file: Express.MulterS3.File) {
+        if (!file.location) {
+            throw S3Exception.URL_NOT_FOUND;
+        }
+
+        const refinedIsVisible = Boolean(Number(dto.isVisible));
+        let order = null;
+        if (refinedIsVisible) {
+            const maxOrder = await this.entityManager
+                .createQueryBuilder(Banner, 'b')
+                .select('b.orders AS orders')
+                .orderBy('orders', 'DESC')
+                .limit(1)
+                .getRawOne();
+            maxOrder ? (order = Number(maxOrder.orders) + 1) : (order = 1);
+        }
+
+        const newBanner = this.bannerRepository.create({
+            ...dto,
+            isVisible: refinedIsVisible,
+            url: file.location,
+            orders: order,
+        });
+
+        await this.bannerRepository.save(newBanner).catch((error) => {
+            if (error.errno == 1062) {
+                throw BannerException.ALREADY_EXIST_BANNER;
+            } else throw error;
+        });
+    }
+}

--- a/src/banners/dto/create-banner.dto.ts
+++ b/src/banners/dto/create-banner.dto.ts
@@ -1,0 +1,15 @@
+import { IsBoolean, IsNotEmpty, IsString, IsUrl, isURL } from 'class-validator';
+import { CreateBannerInterface } from '../interface/create-banner.interface';
+
+export class CreateBannerDto implements CreateBannerInterface {
+    @IsNotEmpty()
+    @IsString()
+    name: string;
+
+    @IsString()
+    description: string;
+
+    @IsNotEmpty()
+    @IsBoolean()
+    isVisible: boolean;
+}

--- a/src/banners/entity/banner.entity.ts
+++ b/src/banners/entity/banner.entity.ts
@@ -1,0 +1,20 @@
+import { AbstractEntity } from 'src/global/common/abstract.entity';
+import { Column, Entity } from 'typeorm';
+
+@Entity({ name: 'banners' })
+export class Banner extends AbstractEntity<Banner> {
+    @Column({})
+    name: string;
+
+    @Column({})
+    url: string;
+
+    @Column({ nullable: true })
+    description: string;
+
+    @Column({ default: 0 })
+    isVisible: boolean;
+
+    @Column({})
+    order: number;
+}

--- a/src/banners/entity/banner.entity.ts
+++ b/src/banners/entity/banner.entity.ts
@@ -12,9 +12,9 @@ export class Banner extends AbstractEntity<Banner> {
     @Column({ nullable: true })
     description: string;
 
+    @Column({ nullable: true })
+    orders: number;
+
     @Column({ default: 0 })
     isVisible: boolean;
-
-    @Column({})
-    order: number;
 }

--- a/src/banners/interface/create-banner.interface.ts
+++ b/src/banners/interface/create-banner.interface.ts
@@ -1,0 +1,5 @@
+export interface CreateBannerInterface {
+    readonly name: string;
+    readonly description: string;
+    readonly isVisible: boolean;
+}

--- a/src/global/config/multer-s3.config.ts
+++ b/src/global/config/multer-s3.config.ts
@@ -4,6 +4,7 @@ import { MulterOptions } from '@nestjs/platform-express/multer/interfaces/multer
 import * as multerS3 from 'multer-s3';
 import * as mime from 'mime-types';
 import { Request } from 'express';
+import { S3Exception } from '../exception/s3-exception';
 
 export const multerS3Config = (configService: ConfigService): MulterOptions => {
     const s3 = new S3Client({
@@ -24,7 +25,7 @@ export const multerS3Config = (configService: ConfigService): MulterOptions => {
                 const pathParam = req.path.split('/');
                 let savedPath: string = '';
                 let dataType: string = '';
-                // pathParam[3] -> stores or menus
+                // pathParam[3] -> stores or menus or banners
                 // pathParam[4] -> upload
                 // pathParam[5] -> :storeId
                 switch (pathParam[3]) {
@@ -36,6 +37,12 @@ export const multerS3Config = (configService: ConfigService): MulterOptions => {
                         savedPath = 'stores' + '/ID: ' + pathParam[5] + '/menus';
                         dataType = 'menuImage';
                         break;
+                    case 'banners':
+                        savedPath = 'banners';
+                        dataType = 'bannerImage';
+                        break;
+                    default:
+                        cb(S3Exception.URL_NOT_FOUND);
                 }
                 const currentDate = new Date();
                 const formattedDate = currentDate.toISOString().replace(/:/g, '-').slice(0, -5);
@@ -52,7 +59,7 @@ export const multerS3Config = (configService: ConfigService): MulterOptions => {
             if (allowedMimeTypes.includes(file.mimetype)) {
                 callback(null, true); // 허용
             } else {
-                callback(new Error('Invalid file type. Only JPEG, PNG, and GIF images are allowed.'), false); // 거부
+                callback(S3Exception.NOT_ALLOWED_EXTENSION, false);
             }
         },
     };

--- a/src/global/config/multer-s3.config.ts
+++ b/src/global/config/multer-s3.config.ts
@@ -24,29 +24,30 @@ export const multerS3Config = (configService: ConfigService): MulterOptions => {
             key: function (req: Request, file, cb) {
                 const pathParam = req.path.split('/');
                 let savedPath: string = '';
-                let dataType: string = '';
+                let uploadedName: string = '';
                 // pathParam[3] -> stores or menus or banners
                 // pathParam[4] -> upload
                 // pathParam[5] -> :storeId
                 switch (pathParam[3]) {
                     case 'stores':
                         savedPath = 'stores' + '/ID: ' + pathParam[5];
-                        dataType = 'storeImage';
+                        uploadedName = 'storeImage';
                         break;
                     case 'menus':
                         savedPath = 'stores' + '/ID: ' + pathParam[5] + '/menus';
-                        dataType = 'menuImage';
+                        uploadedName = 'menuImage';
                         break;
                     case 'banners':
                         savedPath = 'banners';
-                        dataType = 'bannerImage';
+                        const extensionIdx = file.originalname.lastIndexOf('.'); // 확장자 온점 idx번호
+                        uploadedName = file.originalname.slice(0, extensionIdx); // 확장자 전까지만 기록
                         break;
                     default:
                         cb(S3Exception.URL_NOT_FOUND);
                 }
                 const currentDate = new Date();
-                const formattedDate = currentDate.toISOString().replace(/:/g, '-').slice(0, -5);
-                cb(null, `${savedPath}/${dataType} ${formattedDate}.${mime.extension(file.mimetype)}`);
+                const formattedDate = currentDate.toISOString().replace(/:/g, '-').slice(0, -5); // 2024-01-08T07-15-59 <- 위와 같은 모양새
+                cb(null, `${savedPath}/${uploadedName} ${formattedDate}.${mime.extension(file.mimetype)}`);
             },
         }),
         limits: {

--- a/src/global/exception/banners-exception.ts
+++ b/src/global/exception/banners-exception.ts
@@ -1,0 +1,10 @@
+import { HttpStatus } from '@nestjs/common';
+import { CommonException } from './common-exception';
+
+export abstract class BannerException {
+    static ALREADY_EXIST_BANNER = new CommonException(
+        '이미 존재하는 배너입니다.',
+        8000,
+        HttpStatus.UNPROCESSABLE_ENTITY,
+    );
+}

--- a/src/global/exception/s3-exception.ts
+++ b/src/global/exception/s3-exception.ts
@@ -9,4 +9,6 @@ export abstract class S3Exception {
         9001,
         HttpStatus.BAD_REQUEST,
     );
+
+    static UPLOAD_FAIL = new CommonException('사진 업로드에 실패했습니다.', 9002, HttpStatus.BAD_REQUEST);
 }

--- a/src/global/exception/s3-exception.ts
+++ b/src/global/exception/s3-exception.ts
@@ -1,0 +1,12 @@
+import { HttpStatus } from '@nestjs/common';
+import { CommonException } from './common-exception';
+
+export abstract class S3Exception {
+    static URL_NOT_FOUND = new CommonException('업로드의 주소가 일치하지 않습니다.', 9000, HttpStatus.NOT_FOUND);
+
+    static NOT_ALLOWED_EXTENSION = new CommonException(
+        '파일의 확장자가 지원되지않습니다.',
+        9001,
+        HttpStatus.BAD_REQUEST,
+    );
+}

--- a/src/global/util/database.config.generator.ts
+++ b/src/global/util/database.config.generator.ts
@@ -1,5 +1,6 @@
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { Token } from 'src/auth/entity/token.entity';
+import { Banner } from 'src/banners/entity/banner.entity';
 import { Category } from 'src/categories/entity/category.entity';
 import { MenuView } from 'src/menus/entity/menu-view.entity';
 import { Menu } from 'src/menus/entity/menu.entity';
@@ -51,6 +52,7 @@ export const configGenerator = (env: string): TypeOrmModuleOptions => {
                 Token,
                 Tag,
                 Version,
+                Banner,
             ],
             namingStrategy: new SnakeNamingStrategy(),
         };

--- a/test/banners/banners.controller.spec.ts
+++ b/test/banners/banners.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BannersController } from 'src/banners/banners.controller';
+
+describe('BannersController', () => {
+    let controller: BannersController;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [BannersController],
+        }).compile();
+
+        controller = module.get<BannersController>(BannersController);
+    });
+
+    it('should be defined', () => {
+        expect(controller).toBeDefined();
+    });
+});

--- a/test/banners/banners.service.spec.ts
+++ b/test/banners/banners.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BannersService } from 'src/banners/banners.service';
+
+describe('BannersService', () => {
+    let service: BannersService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [BannersService],
+        }).compile();
+
+        service = module.get<BannersService>(BannersService);
+    });
+
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
+});


### PR DESCRIPTION
## 배너 조회 및 생성 로직 구현
- S3의 banners 폴더 안에 이미지 저장
- banners entity를 별도로 생성해 isVisible, orders를 이용해 banner 조회 로직 구현
- banner의 설명을 위하여 banners entity에 name, description 저장

### 특이사항
- S3 업로드시 에러 핸들링 구현
- banner 중복 추가시 에러 핸들링 구현