### PR TITLE
KS-125: Admin Guard 추가 및 적용

### DIFF
--- a/src/auth/guard/admin.guard.ts
+++ b/src/auth/guard/admin.guard.ts
@@ -1,0 +1,30 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { JwtService } from '@nestjs/jwt';
+import { Request } from 'express';
+import { User } from 'src/users/entity/user.entity';
+import { AuthException } from 'src/global/exception/auth-exception';
+import { Roles } from 'src/users/enum/roles.enum';
+import { UsersException } from 'src/global/exception/users-exception';
+
+interface RequestUser extends Request {
+    user: User;
+}
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+    constructor() {}
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const request: RequestUser = context.switchToHttp().getRequest();
+        if (!request.user) {
+            throw UsersException.NOT_EXIST_USER;
+        }
+
+        const role = request.user.role;
+        if (role !== Roles.ADMIN) {
+            throw AuthException.DENINED_USER_NOT_ADMIN;
+        }
+        return true;
+    }
+}

--- a/src/banners/banners.controller.ts
+++ b/src/banners/banners.controller.ts
@@ -3,13 +3,14 @@ import { BannersService } from './banners.service';
 import { AuthGuard } from 'src/auth/guard/auth.guard';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { CreateBannerDto } from './dto/create-banner.dto';
+import { AdminGuard } from 'src/auth/guard/admin.guard';
 
 @Controller('banners')
 export class BannersController {
     constructor(private readonly bannerService: BannersService) {}
 
     @Post('/upload')
-    @UseGuards(AuthGuard) // TODO: 어드민 권한
+    @UseGuards(AuthGuard, AdminGuard)
     @UseInterceptors(FileInterceptor('file'))
     async uploadImage(@UploadedFile() file: Express.MulterS3.File, @Body() formData: object) {
         const dto: CreateBannerDto = JSON.parse(JSON.stringify(formData));

--- a/src/banners/banners.service.ts
+++ b/src/banners/banners.service.ts
@@ -16,8 +16,8 @@ export class BannersService {
     ) {}
 
     async create(dto: CreateBannerInterface, file: Express.MulterS3.File) {
-        if (!file.location) {
-            throw S3Exception.URL_NOT_FOUND;
+        if (file === undefined) {
+            throw S3Exception.UPLOAD_FAIL;
         }
 
         const refinedIsVisible = Boolean(Number(dto.isVisible));

--- a/src/global/exception/auth-exception.ts
+++ b/src/global/exception/auth-exception.ts
@@ -39,4 +39,6 @@ export abstract class AuthException {
         1006,
         HttpStatus.INTERNAL_SERVER_ERROR,
     );
+
+    static DENINED_USER_NOT_ADMIN = new CommonException('관리자(Admin)만 접근 가능합니다.', 1007, HttpStatus.FORBIDDEN);
 }

--- a/src/stores/stores.controller.ts
+++ b/src/stores/stores.controller.ts
@@ -31,6 +31,7 @@ import { UseEntityTransformer } from 'src/global/decorator/entity-transformer.de
 import { CAUTION_TEXT } from 'src/global/common/caution.constant';
 import { FindStoreDetailDto } from './dto/find-store-detail.dto';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { AdminGuard } from 'src/auth/guard/admin.guard';
 
 @Controller('stores')
 export class StoresController {
@@ -63,8 +64,8 @@ export class StoresController {
         return await this.storesService.toggleStoreStatus(store);
     }
 
-    // TODO: 어드민 권한
     @Patch('approve/:storeId')
+    @UseGuards(AuthGuard, AdminGuard)
     @UseEntityTransformer<Store>(TransformStoreInterceptor)
     async approve(@CurrentStore() store: Store) {
         return await this.storesService.approve(store);


### PR DESCRIPTION
## 구현사항
- auth쪽에서 admin guard를 추가하였습니다.
- admin 권한이 필요한 작업(현재는 가게 승인 상태 변경, 배너 등록 API)에 admin guard를 추가하여 user의 role !== admin이라면 에러처리 하였습니다.


### 특이사항
- 배너 업로드 도중 S3의 에러처리를 수정하였습니다.