### PR TITLE
KS-132: DynamoDB 동기화 작업

### DIFF
--- a/src/menus/dto/update-menu.dto.ts
+++ b/src/menus/dto/update-menu.dto.ts
@@ -20,6 +20,10 @@ export class UpdateMenuDto implements UpdateMenuArgs {
     discountRate?: number;
 
     @IsOptional()
+    @IsNumber()
+    sellingPrice?: number;
+
+    @IsOptional()
     @IsString()
     description?: string;
 }

--- a/src/menus/interface/find-detail-one-menu.interface.ts
+++ b/src/menus/interface/find-detail-one-menu.interface.ts
@@ -1,21 +1,13 @@
-import { Store } from 'src/stores/entity/store.entity';
-import { Menu } from '../entity/menu.entity';
 import { FindSimpleOneMenu } from './find-simple-one-menu.interface';
 
 export interface FindDetailOneMenu {
-    mainMenuPictureUrl: Pick<Menu, 'menuPictureUrl'>;
-    description: Pick<Menu, 'description'>;
-    name: Pick<Menu, 'name'>;
-    discountRate: Pick<Menu, 'discountRate'>;
-    price: Pick<Menu, 'price'>;
-    //viewCount: Pick<Menu, 'viewCount'>;
-    storeNmae: Pick<Store, 'name'>;
-    //storeAddress: Pick<Store, 'address'>;
-    //phone: Pick<Store, 'phone'>;
-    expiredDate: null;
-    //storeLatitude: Pick<Store, 'latitude'>;
-    //storeLongitude: Pick<Store, 'longitude'>;
-    //countryOfOrigin: Pick<Store, 'countryOfOrigin'>;
+    mainMenuPictureUrl: string;
+    description: string;
+    name: string;
+    discountRate: number;
+    price: number;
+    storeName: string;
+    expiredDate?: Date;
     anotherMenus: FindSimpleOneMenu[];
     notice: string[];
 }

--- a/src/menus/interface/update-menu.interface.ts
+++ b/src/menus/interface/update-menu.interface.ts
@@ -1,9 +1,8 @@
-import { MenuStatus } from '../enum/menu-status.enum';
-
 export interface UpdateMenuArgs {
     menuPictureUrl?: string;
     name?: string;
     description?: string;
     price?: number;
     discountRate?: number;
+    sellingPrice?: number;
 }

--- a/src/menus/menus.service.ts
+++ b/src/menus/menus.service.ts
@@ -47,6 +47,9 @@ export class MenusService {
         if (!storeData) {
             throw StoresException.ENTITY_NOT_FOUND;
         }
+        if (user !== storeData.user) {
+            throw MenusException.HAS_NO_PERMISSION_CREATE;
+        }
         await this.validateUserRole(user, Roles.OWNER);
         const createdMenu = await this.menusRepository.create(storeData, args);
         await this.storesRepository.addOrder(storeData, createdMenu);

--- a/src/menus/menus.service.ts
+++ b/src/menus/menus.service.ts
@@ -91,7 +91,10 @@ export class MenusService {
 
     async update(menu: Menu, args: UpdateMenuArgs) {
         await this.menusRepository.update(menu, { ...args });
-        return await this.findDetailOne(menu);
+        const result = await this.findDetailOne(menu);
+        const dynamoMenuData = await this.dynamoModel.get({ storeName: result.storeName, menuId: menu.id });
+        await this.dynamoModel.update({ ...dynamoMenuData, ...args, menuName: args.name ? args.name : result.name }); // TODO name칼럼 좀 이쁘게 변환할 순 없을까?
+        return;
     }
 
     async delete(menu: Menu) {

--- a/src/menus/menus.service.ts
+++ b/src/menus/menus.service.ts
@@ -1,14 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { MenusRepository } from './menus.repository';
-import {
-    EntityManager,
-    FindManyOptions,
-    FindOptionsRelations,
-    FindOptionsSelect,
-    FindOptionsWhere,
-    createQueryBuilder,
-} from 'typeorm';
+import { EntityManager, FindManyOptions, FindOptionsRelations, FindOptionsSelect, FindOptionsWhere } from 'typeorm';
 import { UsersRepository } from 'src/users/users.repository';
 import { StoresRepository } from 'src/stores/stores.repository';
 import { Store } from 'src/stores/entity/store.entity';
@@ -33,6 +26,9 @@ import { StoreStatus } from 'src/stores/enum/store-status.enum';
 import { StoreApprove } from 'src/stores/entity/store-approve.entity';
 import { UpdateStatusArgs } from './interface/update-status.interface';
 import { StoreApproveStatus } from 'src/stores/enum/store-approve-status.enum';
+import { InjectModel, Model } from 'nestjs-dynamoose';
+import { DynamoKey, DynamoSchema } from 'src/stores/interfaces/store-menu-dynamo.interface';
+import { DynamoException } from 'src/global/exception/dynamo-exception';
 
 @Injectable()
 export class MenusService {
@@ -41,7 +37,8 @@ export class MenusService {
         private readonly entityManager: EntityManager,
         private readonly usersRepository: UsersRepository,
         private readonly storesRepository: StoresRepository,
-        private readonly configService: ConfigService,
+        @InjectModel('Store-Menu')
+        private dynamoModel: Model<DynamoSchema, DynamoKey>,
     ) {}
 
     async create(user: User, args: CreateMenuArgs) {
@@ -51,10 +48,42 @@ export class MenusService {
             throw StoresException.ENTITY_NOT_FOUND;
         }
         await this.validateUserRole(user, Roles.OWNER);
-        const createdId = await this.menusRepository.create(storeData, args);
-        const menuData: Menu = await this.menusRepository.findOne({ id: createdId });
-        await this.storesRepository.addOrder(storeData, menuData);
-        return { menuId: createdId };
+        const createdMenu = await this.menusRepository.create(storeData, args);
+        await this.storesRepository.addOrder(storeData, createdMenu);
+        const dynamoInsertData = {
+            storeName: storeData.name,
+            menuId: createdMenu.id,
+            menuName: createdMenu.name,
+            menuPictureUrl: createdMenu.menuPictureUrl,
+            sellingPrice: createdMenu.salePrice,
+            discountRate: createdMenu.discountRate,
+            viewCount: 0,
+        };
+        try {
+            await this.dynamoModel.create(dynamoInsertData);
+        } catch (error) {
+            switch (error.code) {
+                case 'ConditionalCheckFailedException':
+                    throw DynamoException.CONDITION_CHECK_FAILED;
+                case 'ProvisionedThroughputExceededException':
+                    throw DynamoException.PROVISIONED_THROUGHPUT_EXCEEDED;
+                case 'ItemCollectionSizeLimitExceededException':
+                    throw DynamoException.ITEM_COLLECTION_SIZE_LIMIT_EXCEEDED;
+                case 'ResourceNotFoundException':
+                    throw DynamoException.RESOURCE_NOT_FOUND;
+                case 'LimitExceededException':
+                    throw DynamoException.Limit_Exceeded;
+                case 'RequestLimitExceeded':
+                    throw DynamoException.Request_Limit_Exceeded;
+                case 'ValidationException':
+                    throw DynamoException.VALIDATION_ERROR;
+                case 'TransactionConflictException':
+                    throw DynamoException.TRANSACTION_CONFLICT;
+                case 'InternalServerError':
+                    throw DynamoException.INTERNAL_SERVER_ERROR;
+            }
+        }
+        return { menuId: createdMenu.id };
     }
 
     async update(menu: Menu, args: UpdateMenuArgs) {
@@ -102,7 +131,7 @@ export class MenusService {
             pickUpTime: refinedPickUpTime ? refinedPickUpTime : null, // 사용자의 거리값을 안 보냈을 경우(update 시) null로 전송
             caution,
         };
-        await this.menusRepository.incrementView(menu);
+        await this.menusRepository.incrementView(menu, data.storeName);
         return menuDetailList;
     }
 
@@ -440,9 +469,8 @@ export class MenusService {
                     countryOfOrigin: countryOfOrigins,
                 };
                 i++;
-                const createdId = await this.menusRepository.create(storeInfo, { ...mockMenu });
-                const menuData: Menu = await this.menusRepository.findOne({ id: createdId });
-                await this.storesRepository.addOrder(storeInfo, menuData);
+                const createdMenu = await this.menusRepository.create(storeInfo, { ...mockMenu });
+                await this.storesRepository.addOrder(storeInfo, createdMenu);
             }
         }
     }

--- a/src/stores/stores.service.ts
+++ b/src/stores/stores.service.ts
@@ -248,16 +248,16 @@ export class StoresService {
 
     async migrateDynamo() {
         const dataList = await this.entityManager
-            .createQueryBuilder(Menu, 'menus')
-            .leftJoinAndSelect(Store, 'stores', 'stores.id = menus.store_id')
-            .leftJoinAndSelect(MenuView, 'menu_views', 'menus.id = menu_views.menu_id')
-            .select('stores.name AS storeName')
-            .addSelect('menus.id AS menuId')
-            .addSelect('menus.name AS menuName')
-            .addSelect('menus.menu_picture_url AS menuPictureUrl')
-            .addSelect('menus.price AS sellingPrice')
-            .addSelect('menus.discount_rate AS discountRate')
-            .addSelect('menu_views.view_count AS viewCount')
+            .createQueryBuilder(Menu, 'm')
+            .leftJoinAndSelect(Store, 's', 's.id = m.store_id')
+            .leftJoinAndSelect(MenuView, 'mv', 'm.id = mv.menu_id')
+            .select('s.name AS storeName')
+            .addSelect('m.id AS menuId')
+            .addSelect('m.name AS menuName')
+            .addSelect('m.menu_picture_url AS menuPictureUrl')
+            .addSelect('m.price AS sellingPrice')
+            .addSelect('m.discount_rate AS discountRate')
+            .addSelect('mv.view_count AS viewCount')
             .getRawMany();
         for (const data of dataList) {
             const isExist = await this.dynamoModel.get({
@@ -271,7 +271,7 @@ export class StoresService {
                     storeName: data.storeName,
                     menuId: data.menuId,
                     menuName: data.menuName,
-                    menuPictureUrl: data.menuPictureUrl,
+                    menuPictureUrl: data.menuPictureUrl ? data.menuPictureUrl : undefined, // null값이면 아예 dynamo에 안들어감
                     sellingPrice: data.sellingPrice,
                     discountRate: data.discountRate,
                     viewCount: data.viewCount,

--- a/src/stores/stores.service.ts
+++ b/src/stores/stores.service.ts
@@ -271,7 +271,7 @@ export class StoresService {
                     storeName: data.storeName,
                     menuId: data.menuId,
                     menuName: data.menuName,
-                    menuPictureUrl: data.menuPictureUrl ? data.menuPictureUrl : undefined, // null값이면 아예 dynamo에 안들어감
+                    menuPictureUrl: data.menuPictureUrl ? data.menuPictureUrl : undefined, // TODO 프론트에 값 넘겨줄떄, null값으로 변환 후 보내주기. (null값이면 아예 dynamo에 안들어감)
                     sellingPrice: data.sellingPrice,
                     discountRate: data.discountRate,
                     viewCount: data.viewCount,


### PR DESCRIPTION
## DynamoDB 동기화 작업
- migrateDynamo를 제외한 메뉴 추가, 수정, 삭제에서 DyanmoDB에 적용
- 조회수 증가시(메뉴 상세 조회시) DynamoDB에 적용


### 특이사항
- 메뉴 수정에서 판매가(sellingPrice)를 못 변경하던걸 수정
- 타입 FindDetailOneMenu에서 Pick으로 사용하던걸 변경
- 메뉴 수정의 성능을 개선