### PR TITLE
KS-133: 가게 운영 상태 관리 로직 변경

### DIFF
--- a/src/stores/entity/store-approve.entity.ts
+++ b/src/stores/entity/store-approve.entity.ts
@@ -5,7 +5,7 @@ import { StoreApproveStatus } from '../enum/store-approve-status.enum';
 
 @Entity()
 export class StoreApprove extends AbstractEntity<StoreApprove> {
-    @Column({ type: 'enum', enum: StoreApproveStatus, default: StoreApproveStatus.BEFORE })
+    @Column({ type: 'enum', enum: StoreApproveStatus, default: StoreApproveStatus.WAITING })
     isApproved: StoreApproveStatus;
 
     @OneToOne(() => Store, (store) => store.approve, { onDelete: 'CASCADE' })

--- a/src/stores/enum/store-approve-status.enum.ts
+++ b/src/stores/enum/store-approve-status.enum.ts
@@ -1,5 +1,4 @@
 export enum StoreApproveStatus {
-    BEFORE = 'before',
     WAITING = 'waiting',
     DONE = 'done',
 }


### PR DESCRIPTION
## 가게 운영 상태 관리 로직 변경
- StoreStatusEnum중 before(가게 생성 전)을 삭제하였습니다.
- 그러므로 StoreStatusEnum는 waiting(가게 승인 대기), done(가게 승인)으로 구분됩니다.