### PR TITLE
KS-186: 원산지표기 삽입&수정 에러 해결

### DIFF
--- a/src/menus/dto/create-menu.dto.ts
+++ b/src/menus/dto/create-menu.dto.ts
@@ -1,7 +1,25 @@
-import { IsDateString, IsEnum, IsNotEmpty, IsNumber, IsOptional, IsString, IsUrl } from 'class-validator';
+import {
+    IsDateString,
+    IsDefined,
+    IsEnum,
+    IsNotEmpty,
+    IsNumber,
+    IsOptional,
+    IsString,
+    IsUrl,
+    ValidateNested,
+} from 'class-validator';
 import { CreateMenuArgs } from '../interface/create-menu.interface';
 import { MenuStatus } from '../enum/menu-status.enum';
+import { Type } from 'class-transformer';
 
+export class CountryOfOrigin {
+    @IsString()
+    ingredient: string;
+
+    @IsString()
+    origin: string;
+}
 export class CreateMenuDto implements CreateMenuArgs {
     @IsNumber()
     @IsNotEmpty()
@@ -38,4 +56,9 @@ export class CreateMenuDto implements CreateMenuArgs {
     @IsString()
     @IsOptional()
     description?: string;
+
+    @IsDefined()
+    @ValidateNested({ each: true })
+    @Type(() => CountryOfOrigin)
+    countryOfOrigin: CountryOfOrigin[];
 }

--- a/src/menus/dto/update-menu.dto.ts
+++ b/src/menus/dto/update-menu.dto.ts
@@ -1,6 +1,7 @@
-import { IsDateString, IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
-import { MenuStatus } from '../enum/menu-status.enum';
+import { IsDateString, IsNotEmpty, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { UpdateMenuArgs } from '../interface/update-menu.interface';
+import { Type } from 'class-transformer';
+import { CountryOfOrigin } from './create-menu.dto';
 
 export class UpdateMenuDto implements UpdateMenuArgs {
     @IsOptional()
@@ -30,4 +31,9 @@ export class UpdateMenuDto implements UpdateMenuArgs {
     @IsOptional()
     @IsDateString()
     expiredDate?: string;
+
+    @IsOptional()
+    @ValidateNested({ each: true })
+    @Type(() => CountryOfOrigin)
+    countryOfOrigin?: CountryOfOrigin[];
 }

--- a/src/menus/entity/menu.entity.ts
+++ b/src/menus/entity/menu.entity.ts
@@ -30,7 +30,7 @@ export class Menu extends SoftDeleteEntity<Menu> {
     @Column({ type: 'enum', enum: MenuStatus, comment: '메뉴 상태', default: MenuStatus.SALE })
     status: MenuStatus;
 
-    @Column({ type: 'json', comment: '원산지 표기', nullable: true })
+    @Column({ type: 'json', comment: '원산지 표기' })
     countryOfOrigin: { ingredient: string; origin: string }[];
 
     @Column({ comment: '메뉴 유통기한', nullable: true })

--- a/src/menus/interface/update-menu.interface.ts
+++ b/src/menus/interface/update-menu.interface.ts
@@ -1,3 +1,5 @@
+import { CountryOfOrigin } from '../dto/create-menu.dto';
+
 export interface UpdateMenuArgs {
     menuPictureUrl?: string;
     name?: string;
@@ -6,4 +8,5 @@ export interface UpdateMenuArgs {
     discountRate?: number;
     sellingPrice?: number;
     expiredDate?: string;
+    countryOfOrigin?: CountryOfOrigin[];
 }


### PR DESCRIPTION
## 🤔 Motivation 

- 원산지표기 삽입&수정이 안되던 에러 해결

<br>

## 🔑 Key Changes

- menu테이블의 원산지표기 nullable(If, 점주가 원산지를 안 보낼경우도 빈배열로 보냄)
- create, update menu dto에 원산지표기 칼럼 추가

<br>
